### PR TITLE
do not report success on failed metadata save

### DIFF
--- a/www/edit.php
+++ b/www/edit.php
@@ -66,7 +66,9 @@ if (isset($_POST['submit'])) {
 	} catch(Exception $e) {}
 	if ($testmetadata) requireOwnership($testmetadata, $userid);
 	
-	$mdh->saveMetadata($metadata['entityid'], 'saml20-sp-remote', $metadata);
+	if(FALSE === $mdh->saveMetadata($metadata['entityid'], 'saml20-sp-remote', $metadata)){
+		throw new Exception("Could not save metadata. See log for details");
+	}
 	
 	$template = new SimpleSAML_XHTML_Template($config, 'metaedit:saved.php');
 	$template->show();


### PR DESCRIPTION
(Migrated PR from https://github.com/simplesamlphp/simplesamlphp/pull/217 )
Hi,

The saving goes through MetaDataStorageHandlerSerialize.php. If the directory does not exist yet, the handler tries to create it first. if something goes wrong, logs error and returns with FALSE.
The caller in modules/metaedt/www/edit.php doesn't check the return value from saveMetadata(), then reports successful saving.
